### PR TITLE
Revert "Bump rollup from 1.21.2 to 1.22.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8291,20 +8291,26 @@
 			}
 		},
 		"rollup": {
-			"version": "1.22.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.22.0.tgz",
-			"integrity": "sha512-x4l4ZrV/Mr/x/jvFTmwROdEAhbZjx16yDRTVSKWh/i4oJDuW2dVEbECT853mybYCz7BAitU8ElGlhx7dNjw3qQ==",
+			"version": "1.21.2",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-1.21.2.tgz",
+			"integrity": "sha512-sCAHlcQ/PExU5t/kRwkEWHdhGmQrZ2IgdQzbjPVNfhWbKHMMZGYqkASVTpQqRPLtQKg15xzEscc+BnIK/TE7/Q==",
 			"dev": true,
 			"requires": {
-				"@types/estree": "*",
-				"@types/node": "*",
-				"acorn": "^7.1.0"
+				"@types/estree": "0.0.39",
+				"@types/node": "^12.7.4",
+				"acorn": "^7.0.0"
 			},
 			"dependencies": {
+				"@types/node": {
+					"version": "12.7.4",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.4.tgz",
+					"integrity": "sha512-W0+n1Y+gK/8G2P/piTkBBN38Qc5Q1ZSO6B5H3QmPCUewaiXOo2GCAWZ4ElZCcNhjJuBSUSLGFUJnmlCn5+nxOQ==",
+					"dev": true
+				},
 				"acorn": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-					"integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+					"integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
 					"dev": true
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"npm-run-all": "4.1.5",
 		"postcss": "7.0.18",
 		"prettier": "1.18.2",
-		"rollup": "1.22.0",
+		"rollup": "1.21.2",
 		"rollup-plugin-babel": "4.3.3",
 		"rollup-plugin-commonjs": "10.1.0",
 		"rollup-plugin-livereload": "1.0.1",


### PR DESCRIPTION
Reverts YogliB/svelte-component-template#179