### PR TITLE
Fix degit instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 ```bash
 npx degit YogliB/svelte-component-template my-new-component
 or
-npx degit YogliB/svelte-component-template my-new-component#monorepo
+npx degit "YogliB/svelte-component-template#monorepo" my-new-component
 ```
 
 3. `cd` into the folder and install the `node_modules`:


### PR DESCRIPTION
I suppose that the hash identifier in `degit` is to be appended to the source template name rather than the target directory name. (as in https://github.com/sveltejs/sapper#get-started)
Thank you for maintaining the template!
